### PR TITLE
Fix block reward calculation to be more accurate.

### DIFF
--- a/lib/Rpc.js
+++ b/lib/Rpc.js
@@ -94,16 +94,36 @@ Rpc.getBlock = function(hash, cb) {
     // Not found?
     if (err) return cb(self.errMsg(err));
     if (info.result.height) {
-      if (info.result.tx.length > 0) {
-   	bitcoreRpc.getRawTransaction(info.result.tx[0], 1, function(err, txInfo) {
-          if (err) info.result.reward = 0;
-	  else {
-	    if (txInfo.result && txInfo.result.vin && txInfo.result.vin.length > 0 && txInfo.result.vin[0].coinbase) 
-              info.result.reward = parseInt(txInfo.result.vin[0].amountin) / bitcore.util.COIN;
-	    else 
-              info.result.reward = 0;
-	  }
-        });
+	   // Set magic numbers from dcrd/chaincfg/params.go
+      var reductionInterval = 6144;
+      var base = 3119582664;
+      var mulSubsidy = 100;
+      var divSubsidy = 101;
+      var workProportion = 6;
+      var stakeProportion = 3;
+      var taxProportion = 1;
+
+      // Calculate number of base subidy reductions that have been done    
+      var numReductions = Math.floor(info.result.heigh / reductionInterval);
+
+      for (var i = 0; i < numReductions; i++) {
+        base *= mulSubsidy
+        base /= divSubsidy
+      }
+
+      // Number of voters for the block in question
+      var voters = info.result.voters;
+
+      // Calculate the 3 different portions of block reward
+      var work = Math.round(base * workProportion / 10 * voters / 5);
+      var stake = Math.round(base * stakeProportion / 10 * voters / 5);
+      var tax = Math.round(base * taxProportion / 10 * voters / 5);
+
+      // If block height is below mainnet voting height, leave out stake
+      if (info.result.height < 4096) {
+        info.result.reward = (work + tax) / bitcore.util.COIN;
+      } else {
+        info.result.reward = (work + stake + tax) / bitcore.util.COIN;
       }
     }
     return cb(err,info.result);


### PR DESCRIPTION
Also does not rely on querying all of the blocks' txs via RPC to calculate current block reward.

May be off by 1-2 atoms depending on Math.Round() but I figure that is acceptable for non-critical information for display. 
