### PR TITLE
Add voters and freshstake fields to returned block list info

### DIFF
--- a/app/controllers/blocks.js
+++ b/app/controllers/blocks.js
@@ -141,7 +141,8 @@ exports.list = function(req, res) {
               hash: b.hash,
               time: b.ts || info.time,
               txlength: info.tx.length,
-              poolInfo: info.poolInfo
+	      voters: info.voters,
+	      freshstake: info.freshstake
             });
           });
         }, function(err, allblocks) {


### PR DESCRIPTION
Along with insight PR this will allow number of votes and fresh stake to be seen on block tables.
